### PR TITLE
Den/issue11 unilize flux and mono

### DIFF
--- a/api-server/src/main/java/org/opennms/devjam2022/apiserver/controller/UserController.java
+++ b/api-server/src/main/java/org/opennms/devjam2022/apiserver/controller/UserController.java
@@ -1,5 +1,6 @@
 package org.opennms.devjam2022.apiserver.controller;
 
+import java.util.List;
 import org.opennms.devjam2022.apiserver.service.IUserService;
 import org.opennms.devjam2022.apiserver.model.UserRole;
 import org.opennms.devjam2022.apiserver.model.UserWithRoles;
@@ -7,13 +8,11 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.*;
-import reactor.core.publisher.Flux;
-import reactor.core.publisher.Mono;
 
 /**
  * This is the first (hence the "v1") implementation of the api-server for BFF tests
- * this one will be using "blocking" calls to the underlying service simulating a
- * "legacy" api-server which is not "adapted" to the new BFF architecture/concept
+ * this one will NOT be using the "reactive" spring-boot application but instead returns
+ * "usual" responses imitating "simple" api-server, unadapted to the "reactive" world
  */
 @RestController
 @RequestMapping("/v1/users")
@@ -24,29 +23,29 @@ public class UserController {
     IUserService userService;
 
     @GetMapping()
-    public Flux<UserWithRoles> all() {
-        return Flux.fromIterable(userService.getUsers());
+    public List<UserWithRoles> all() {
+        return userService.getUsers();
     }
 
     @GetMapping("/{id}")
-    public Mono<UserWithRoles> getUserByID(@PathVariable String id) {
-        return Mono.just(userService.getUserByID(id));
+    public UserWithRoles getUserByID(@PathVariable String id) {
+        return userService.getUserByID(id);
 
     }
 
     @GetMapping("/{userIdentity}/roles")
-    public Flux<UserRole> allRoles(@PathVariable String userIdentity) {
-        return Flux.fromIterable(userService.getRoles(userIdentity));
+    public List<UserRole> allRoles(@PathVariable String userIdentity) {
+        return userService.getRoles(userIdentity);
     }
 
     @PostMapping()
-    public Mono<String> addUser(@RequestBody UserWithRoles user) {
-        return Mono.fromCallable(()->userService.addUser(user));
+    public String addUser(@RequestBody UserWithRoles user) {
+        return userService.addUser(user);
     }
 
     @PostMapping("/{userIdentity}/addRole")
-    public Mono<String> addRole(@PathVariable String userIdentity, @RequestBody UserRole role) {
-        return Mono.just(userService.addRole(userIdentity, role));
+    public String addRole(@PathVariable String userIdentity, @RequestBody UserRole role) {
+        return userService.addRole(userIdentity, role);
     }
 
     @DeleteMapping("/{userIdentity}/deleteRole/{roleId}")

--- a/api-server/src/main/java/org/opennms/devjam2022/apiserver/controller/UserControllerNB.java
+++ b/api-server/src/main/java/org/opennms/devjam2022/apiserver/controller/UserControllerNB.java
@@ -1,5 +1,6 @@
 package org.opennms.devjam2022.apiserver.controller;
 
+import org.opennms.devjam2022.apiserver.impl.InMemoryUserServiceNB;
 import org.opennms.devjam2022.apiserver.service.IUserService;
 import org.opennms.devjam2022.apiserver.model.UserRole;
 import org.opennms.devjam2022.apiserver.model.UserWithRoles;
@@ -21,26 +22,35 @@ public class UserControllerNB {
 
     @Qualifier("InMemoryUserServiceNB")
     @Autowired
-    IUserService userService;
+    InMemoryUserServiceNB userService;
 
-    @GetMapping("/")
+    @GetMapping()
     public Flux<UserWithRoles> all() {
-        return Flux.fromIterable(userService.getUsers());
+        return userService.getUsersReactively();
+    }
+
+    @GetMapping("/{id}")
+    public Mono<UserWithRoles> getUserByID(@PathVariable String id) {
+        // For the singe user, we can use the blocking version, there should be no performance gain
+        return Mono.fromCallable(() -> userService.getUserByID(id));
+
     }
 
     @GetMapping("/{userIdentity}/roles")
     public Flux<UserRole> allRoles(@PathVariable String userIdentity) {
-        return Flux.fromIterable(userService.getRoles(userIdentity));
+        return userService.getRolesReactively(userIdentity);
     }
 
-    @PostMapping("/add")
+    @PostMapping()
     public Mono<String> addUser(@RequestBody UserWithRoles user) {
-        return Mono.just(userService.addUser(user));
+        // For the singe user, we can use the blocking version, there should be no performance gain
+        return Mono.fromCallable(() -> userService.addUser(user));
     }
 
     @PostMapping("/{userIdentity}/addRole")
     public Mono<String> addRole(@PathVariable String userIdentity, @RequestBody UserRole role) {
-        return Mono.just(userService.addRole(userIdentity, role));
+        // For the singe user, we can use the blocking version, there should be no performance gain
+        return Mono.fromCallable(() -> userService.addRole(userIdentity, role));
     }
 
     @DeleteMapping("/{userIdentity}/deleteRole/{roleId}")

--- a/api-server/src/main/java/org/opennms/devjam2022/apiserver/controller/UserControllerNB.java
+++ b/api-server/src/main/java/org/opennms/devjam2022/apiserver/controller/UserControllerNB.java
@@ -11,27 +11,21 @@ import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
 /**
- * This is the first (hence the "v1") implementation of the api-server for BFF tests
- * this one will be using "blocking" calls to the underlying service simulating a
- * "legacy" api-server which is not "adapted" to the new BFF architecture/concept
+ * Second version (hence the "v2") implementation of the api-server for BFF tests
+ * Will try to follow the "best practices" for a "reactive" spring-boot application
+ * using non-blocking service of "flux" and "mono" types
  */
 @RestController
-@RequestMapping("/v1/users")
-public class UserController {
+@RequestMapping("/v2/users")
+public class UserControllerNB {
 
-    @Qualifier("InMemoryUserService")
+    @Qualifier("InMemoryUserServiceNB")
     @Autowired
     IUserService userService;
 
     @GetMapping("/")
     public Flux<UserWithRoles> all() {
         return Flux.fromIterable(userService.getUsers());
-    }
-
-    @GetMapping("/{id}")
-    public Mono<UserWithRoles> getUserByID(@PathVariable String id) {
-        return Mono.just(userService.getUserByID(id));
-
     }
 
     @GetMapping("/{userIdentity}/roles")

--- a/api-server/src/main/java/org/opennms/devjam2022/apiserver/impl/InMemoryUserService.java
+++ b/api-server/src/main/java/org/opennms/devjam2022/apiserver/impl/InMemoryUserService.java
@@ -4,7 +4,6 @@ import java.util.*;
 import java.util.stream.Collectors;
 import org.opennms.devjam2022.apiserver.model.UserRole;
 import org.opennms.devjam2022.apiserver.model.UserWithRoles;
-import org.opennms.devjam2022.apiserver.model.utils.ModelUtil;
 import org.opennms.devjam2022.apiserver.service.AbstractInMemoryUserService;
 import org.opennms.devjam2022.apiserver.service.IUserService;
 import org.springframework.stereotype.Component;
@@ -28,56 +27,4 @@ public class InMemoryUserService extends AbstractInMemoryUserService {
         }).collect(Collectors.toList());
     }
 
-    @Override
-    public UserWithRoles getUserByID(String id) {
-        UserWithRoles user = USERS.stream().filter(u -> u.getIdentity().equals(id)).findFirst().orElse(null);
-        if(user != null) {
-            user.setRoles(getRoles(id));
-        }
-        return user;
-    }
-
-
-    @Override
-    public List<UserRole> getRoles(String userIdentity) {
-        List<UserRole> result = USER_ROLES.get(userIdentity);
-        return result == null ? Collections.emptyList() : result;
-    }
-
-    @Override
-    public String addUser(UserWithRoles user) {
-        user.setIdentity(ModelUtil.generateId());
-        USERS.add(user);
-
-        return user.getIdentity();
-    }
-
-    @Override
-    public String addRole(String userIdentity, UserRole role) {
-        role.setId(ModelUtil.generateId());
-
-        if (!USER_ROLES.containsKey(userIdentity)) {
-            USER_ROLES.put(userIdentity, new LinkedList<>());
-        }
-
-        USER_ROLES.get(userIdentity).add(role);
-        return role.getId();
-    }
-
-    @Override
-    public boolean deleteRole(String userIdentity, String roleId) {
-        if (USER_ROLES.containsKey(userIdentity)) {
-            List<UserRole> roles = USER_ROLES.get(userIdentity);
-            return roles.removeIf(role -> role.getId().equals(roleId));
-        } else {
-            return false;
-        }
-    }
-
-    @Override
-    public boolean deleteUser(String userIdentity) {
-        boolean userWasRemoved = USERS.removeIf(user -> user.getIdentity().equals(userIdentity));
-        USER_ROLES.remove(userIdentity);
-        return userWasRemoved;
-    }
 }

--- a/api-server/src/main/java/org/opennms/devjam2022/apiserver/impl/InMemoryUserServiceNB.java
+++ b/api-server/src/main/java/org/opennms/devjam2022/apiserver/impl/InMemoryUserServiceNB.java
@@ -12,8 +12,8 @@ import org.springframework.stereotype.Component;
 /**
  * Simple in-memory implementation of the {@link IUserService} interface.
  */
-@Component("InMemoryUserService")
-public class InMemoryUserService extends AbstractInMemoryUserService {
+@Component("InMemoryUserServiceNB")
+public class InMemoryUserServiceNB extends AbstractInMemoryUserService {
 
     @Override
     public List<UserWithRoles> getUsers() {

--- a/api-server/src/main/java/org/opennms/devjam2022/apiserver/listener/ContextListener.java
+++ b/api-server/src/main/java/org/opennms/devjam2022/apiserver/listener/ContextListener.java
@@ -1,6 +1,7 @@
 package org.opennms.devjam2022.apiserver.listener;
 
 import java.util.Random;
+import org.opennms.devjam2022.apiserver.impl.InMemoryUserServiceNB;
 import static org.opennms.devjam2022.apiserver.model.utils.ModelUtil.createTestRole;
 import static org.opennms.devjam2022.apiserver.model.utils.ModelUtil.createTestUserWithEmptyListRoles;
 import org.opennms.devjam2022.apiserver.service.IUserService;
@@ -21,15 +22,21 @@ public class ContextListener {
     @Autowired
     IUserService userService;
 
+    @Qualifier("InMemoryUserServiceNB")
+    @Autowired
+    InMemoryUserServiceNB userServiceNb;
+
     @EventListener({ContextRefreshedEvent.class})
     public void handleContextRefreshEvent() {
         LOG.info("Context refresh event received");
         for (long i = 0; i < NUMBER_OF_USERS_IN_DB; i++) {
             String userId = userService.addUser(createTestUserWithEmptyListRoles());
+            String userIdNb = userServiceNb.addUser(createTestUserWithEmptyListRoles());
 
             int count = new Random().nextInt(5) + 1; // 1-5 roles to be added
             for (int j = 0; j < count; j++) {
                 userService.addRole(userId, createTestRole());
+                userServiceNb.addRole(userIdNb, createTestRole());
             }
         }
         LOG.info("Added '" + NUMBER_OF_USERS_IN_DB + "' users... to the in-memory database");

--- a/api-server/src/main/java/org/opennms/devjam2022/apiserver/listener/ContextListener.java
+++ b/api-server/src/main/java/org/opennms/devjam2022/apiserver/listener/ContextListener.java
@@ -1,0 +1,37 @@
+package org.opennms.devjam2022.apiserver.listener;
+
+import java.util.Random;
+import static org.opennms.devjam2022.apiserver.model.utils.ModelUtil.createTestRole;
+import static org.opennms.devjam2022.apiserver.model.utils.ModelUtil.createTestUserWithEmptyListRoles;
+import org.opennms.devjam2022.apiserver.service.IUserService;
+import org.slf4j.Logger;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.context.event.ContextRefreshedEvent;
+import org.springframework.context.event.EventListener;
+import org.springframework.stereotype.Component;
+
+@Component
+public class ContextListener {
+    private final static Logger LOG = org.slf4j.LoggerFactory.getLogger(ContextListener.class);
+
+    public static final int NUMBER_OF_USERS_IN_DB = 1000;
+
+    @Qualifier("InMemoryUserService")
+    @Autowired
+    IUserService userService;
+
+    @EventListener({ContextRefreshedEvent.class})
+    public void handleContextRefreshEvent() {
+        LOG.info("Context refresh event received");
+        for (long i = 0; i < NUMBER_OF_USERS_IN_DB; i++) {
+            String userId = userService.addUser(createTestUserWithEmptyListRoles());
+
+            int count = new Random().nextInt(5) + 1; // 1-5 roles to be added
+            for (int j = 0; j < count; j++) {
+                userService.addRole(userId, createTestRole());
+            }
+        }
+        LOG.info("Added '" + NUMBER_OF_USERS_IN_DB + "' users... to the in-memory database");
+    }
+}

--- a/api-server/src/main/java/org/opennms/devjam2022/apiserver/model/utils/ModelUtil.java
+++ b/api-server/src/main/java/org/opennms/devjam2022/apiserver/model/utils/ModelUtil.java
@@ -1,6 +1,10 @@
 package org.opennms.devjam2022.apiserver.model.utils;
 
+import java.util.Collections;
+import java.util.List;
 import java.util.Random;
+import org.opennms.devjam2022.apiserver.model.UserRole;
+import org.opennms.devjam2022.apiserver.model.UserWithRoles;
 
 public class ModelUtil {
     private static final Random ID_GENERATOR = new Random();
@@ -8,5 +12,24 @@ public class ModelUtil {
     public static String generateId() {
         // NOTE: This is a little bit hacky, but it works for us as unsigned LONG example
         return Long.toUnsignedString(ID_GENERATOR.nextLong());
+    }
+
+    public static UserRole createTestRole() {
+        String id = generateId();
+        return new UserRole(id, "TestRole" + id);
+    }
+
+    public static UserWithRoles createTestUserWithEmptyListRoles() {
+        return createTestUserWithRoles(Collections.emptyList());
+    }
+
+    public static UserWithRoles createTestUserWithRoles(List<UserRole> roles) {
+        String id = generateId();
+        return new UserWithRoles(
+                "tst" + id + "@opennms.com",
+                id,
+                "TestName" + id,
+                "TestFamily" + id,
+                roles);
     }
 }

--- a/api-server/src/main/java/org/opennms/devjam2022/apiserver/service/AbstractInMemoryUserService.java
+++ b/api-server/src/main/java/org/opennms/devjam2022/apiserver/service/AbstractInMemoryUserService.java
@@ -1,10 +1,13 @@
 package org.opennms.devjam2022.apiserver.service;
 
 import java.util.ArrayList;
+import java.util.Collections;
+import java.util.LinkedList;
 import java.util.List;
 import java.util.concurrent.ConcurrentHashMap;
 import org.opennms.devjam2022.apiserver.model.UserRole;
 import org.opennms.devjam2022.apiserver.model.UserWithRoles;
+import org.opennms.devjam2022.apiserver.model.utils.ModelUtil;
 
 /**
  * Abstract implementation of the {@link IUserService} that uses an in-memory map to store the users
@@ -14,4 +17,55 @@ public abstract class AbstractInMemoryUserService implements IUserService {
     protected final ConcurrentHashMap<String, List<UserRole>> USER_ROLES = new ConcurrentHashMap<>();
     protected final List<UserWithRoles> USERS = new ArrayList<>();
 
+    // ======== These methods are common to the both (blocking and non-blocking) implementations ========
+    @Override
+    public List<UserRole> getRoles(String userIdentity) {
+        List<UserRole> result = USER_ROLES.get(userIdentity);
+        return result == null ? Collections.emptyList() : result;
+    }
+
+    @Override
+    public UserWithRoles getUserByID(String id) {
+        UserWithRoles user = USERS.stream().filter(u -> u.getIdentity().equals(id)).findFirst().orElse(null);
+        if(user != null) {
+            user.setRoles(getRoles(id));
+        }
+        return user;
+    }
+
+    public String addUser(UserWithRoles user) {
+        user.setIdentity(ModelUtil.generateId());
+        USERS.add(user);
+
+        return user.getIdentity();
+    }
+
+    @Override
+    public String addRole(String userIdentity, UserRole role) {
+        role.setId(ModelUtil.generateId());
+
+        if (!USER_ROLES.containsKey(userIdentity)) {
+            USER_ROLES.put(userIdentity, new LinkedList<>());
+        }
+
+        USER_ROLES.get(userIdentity).add(role);
+        return role.getId();
+    }
+
+    @Override
+    public boolean deleteRole(String userIdentity, String roleId) {
+        if (USER_ROLES.containsKey(userIdentity)) {
+            List<UserRole> roles = USER_ROLES.get(userIdentity);
+            return roles.removeIf(role -> role.getId().equals(roleId));
+        } else {
+            return false;
+        }
+    }
+
+    @Override
+    public boolean deleteUser(String userIdentity) {
+        boolean userWasRemoved = USERS.removeIf(user -> user.getIdentity().equals(userIdentity));
+        USER_ROLES.remove(userIdentity);
+        return userWasRemoved;
+    }
 }

--- a/api-server/src/main/java/org/opennms/devjam2022/apiserver/service/AbstractInMemoryUserService.java
+++ b/api-server/src/main/java/org/opennms/devjam2022/apiserver/service/AbstractInMemoryUserService.java
@@ -1,0 +1,17 @@
+package org.opennms.devjam2022.apiserver.service;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.ConcurrentHashMap;
+import org.opennms.devjam2022.apiserver.model.UserRole;
+import org.opennms.devjam2022.apiserver.model.UserWithRoles;
+
+/**
+ * Abstract implementation of the {@link IUserService} that uses an in-memory map to store the users
+ * and their roles
+ */
+public abstract class AbstractInMemoryUserService implements IUserService {
+    protected final ConcurrentHashMap<String, List<UserRole>> USER_ROLES = new ConcurrentHashMap<>();
+    protected final List<UserWithRoles> USERS = new ArrayList<>();
+
+}

--- a/api-server/src/main/java/org/opennms/devjam2022/apiserver/service/IUserService.java
+++ b/api-server/src/main/java/org/opennms/devjam2022/apiserver/service/IUserService.java
@@ -1,21 +1,36 @@
 package org.opennms.devjam2022.apiserver.service;
 
+import java.util.Collections;
 import java.util.List;
 import org.opennms.devjam2022.apiserver.model.UserRole;
 import org.opennms.devjam2022.apiserver.model.UserWithRoles;
 
 public interface IUserService {
-    List<UserWithRoles> getUsers();
+    default List<UserWithRoles> getUsers() {
+        throw new UnsupportedOperationException("Not implemented yet");
+    }
 
-    UserWithRoles getUserByID(String id);
+    default UserWithRoles getUserByID(String id) {
+        throw new UnsupportedOperationException("Not implemented yet");
+    }
 
-    List<UserRole> getRoles(String userIdentity);
+    default List<UserRole> getRoles(String userIdentity) {
+        throw new UnsupportedOperationException("Not implemented yet");
+    }
 
-    String addUser(UserWithRoles user);
+    default String addUser(UserWithRoles user) {
+        throw new UnsupportedOperationException("Not implemented yet");
+    }
 
-    String addRole(String userIdentity, UserRole role);
+    default String addRole(String userIdentity, UserRole role) {
+        throw new UnsupportedOperationException("Not implemented yet");
+    }
 
-    boolean deleteRole(String userIdentity, String roleId);
+    default boolean deleteRole(String userIdentity, String roleId) {
+        throw new UnsupportedOperationException("Not implemented yet");
+    }
 
-    boolean deleteUser(String userIdentity);
+    default boolean deleteUser(String userIdentity) {
+        throw new UnsupportedOperationException("Not implemented yet");
+    }
 }

--- a/api-server/src/main/java/org/opennms/devjam2022/apiserver/service/IUserService.java
+++ b/api-server/src/main/java/org/opennms/devjam2022/apiserver/service/IUserService.java
@@ -1,4 +1,4 @@
-package org.opennms.devjam2022.apiserver.impl;
+package org.opennms.devjam2022.apiserver.service;
 
 import java.util.List;
 import org.opennms.devjam2022.apiserver.model.UserRole;

--- a/api-server/src/test/java/org/opennms/devjam2022/apiserver/controller/UserControllerTest.java
+++ b/api-server/src/test/java/org/opennms/devjam2022/apiserver/controller/UserControllerTest.java
@@ -18,7 +18,7 @@ public class UserControllerTest {
 
     @Test
     public void testGetUsers() {
-        List<UserWithRoles> users = userController.all().collectList().block();
+        List<UserWithRoles> users = userController.all();
         assertThat(users).isNotNull();
         assertThat(users).isNotEmpty();
     }
@@ -27,10 +27,10 @@ public class UserControllerTest {
     public void testAddUser() {
         UserWithRoles user = createTestUserWithEmptyListRoles();
 
-        String userId = userController.addUser(user).block();
+        String userId = userController.addUser(user);
         assertThat(userId).isNotNull();
 
-        List<UserWithRoles> users = userController.all().collectList().block();
+        List<UserWithRoles> users = userController.all();
         users.stream().filter(u -> u.getIdentity().equals(userId)).findFirst().ifPresentOrElse(u -> {
             assertThat(u.getIdentity()).isEqualTo(user.getIdentity());
             assertThat(u.getGivenName()).isEqualTo(user.getGivenName());
@@ -45,15 +45,15 @@ public class UserControllerTest {
     public void testAddRole() {
         UserWithRoles user = createTestUserWithEmptyListRoles();
 
-        String userId = userController.addUser(user).block();
+        String userId = userController.addUser(user);
         assertThat(userId).isNotNull();
 
         UserRole role = createTestRole();
-        String roleId = userController.addRole(userId, role).block();
+        String roleId = userController.addRole(userId, role);
         assertThat(roleId).isNotNull();
 
         // See that we can see the roles now
-        List<UserRole> roles = userController.allRoles(userId).collectList().block();
+        List<UserRole> roles = userController.allRoles(userId);
         assertThat(roles).isNotNull();
         roles.stream().filter(r -> r.getId().equals(roleId)).findFirst().ifPresentOrElse(r -> {
             assertThat(r.getRole()).isEqualTo(role.getRole());
@@ -62,7 +62,7 @@ public class UserControllerTest {
         });
 
         // And also the user should be there and have all the roles
-        List<UserWithRoles> users = userController.all().collectList().block();
+        List<UserWithRoles> users = userController.all();
         assertThat(users).isNotNull();
         users.stream().filter(u -> u.getIdentity().equals(userId)).findFirst().ifPresentOrElse(u -> {
             assertThat(u.getIdentity()).isEqualTo(user.getIdentity());
@@ -84,35 +84,35 @@ public class UserControllerTest {
     @Test
     public void testDeleteUser() {
         UserWithRoles user = createTestUserWithEmptyListRoles();
-        long userCount = userController.all().collectList().block().size();
+        long userCount = userController.all().size();
 
-        String userId = userController.addUser(user).block();
+        String userId = userController.addUser(user);
         assertThat(userId).isNotNull();
 
-        assertThat(userController.all().collectList().block().size()).isEqualTo(userCount + 1);
+        assertThat(userController.all().size()).isEqualTo(userCount + 1);
 
         userController.deleteUser(userId);
 
-        assertThat(userController.all().collectList().block().size()).isEqualTo(userCount);
+        assertThat(userController.all().size()).isEqualTo(userCount);
     }
 
     @Test
     public void testDeleteRole() {
         UserWithRoles user = createTestUserWithEmptyListRoles();
 
-        String userId = userController.addUser(user).block();
+        String userId = userController.addUser(user);
         assertThat(userId).isNotNull();
 
-        assertThat(userController.all().collectList().block()).isNotEmpty();
+        assertThat(userController.all()).isNotEmpty();
 
         UserRole role = createTestRole();
-        long roleCount = userController.allRoles(userId).collectList().block().size();
-        String roleId = userController.addRole(userId, role).block();
+        long roleCount = userController.allRoles(userId).size();
+        String roleId = userController.addRole(userId, role);
 
-        assertThat(userController.allRoles(userId).collectList().block().size()).isEqualTo(roleCount + 1);
+        assertThat(userController.allRoles(userId).size()).isEqualTo(roleCount + 1);
 
         userController.deleteRole(userId, roleId);
 
-        assertThat(userController.allRoles(userId).collectList().block().size()).isEqualTo(roleCount);
+        assertThat(userController.allRoles(userId).size()).isEqualTo(roleCount);
     }
 }


### PR DESCRIPTION
This is the implementation of the Issue #11 

1: Created V2 of the rest-api which for "big" and massive operations using proper Flux from parallel streams.
2: Version V1 moved "back" to the "usual" state to act as "normal" API, non-reactive one
3: Common code moved to the AbstractService class
4: Reworked the system of creating "initial" data
5: On the start the In-memory DB filled with 1000 generated User/Roles from the point 4 above 